### PR TITLE
Add support for Python 3.11.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: test
 on: [push]
 env:
   test_dir_name: test-workspace
-  cpython_version: "3.10"
+  cpython_version: "3.11"
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ sudo pacman -S --needed curl base-devel openssl zlib xz
 
 ```bash
 mkdir -p ~/.local/bin && \
-  curl -sL -o ~/.local/bin/lonesnake https://github.com/pwalch/lonesnake/releases/download/0.15.0/lonesnake && \
+  curl -sL -o ~/.local/bin/lonesnake https://github.com/pwalch/lonesnake/releases/download/0.16.0/lonesnake && \
   chmod u+x ~/.local/bin/lonesnake
 ```
 
@@ -81,10 +81,10 @@ mkdir -p ~/.local/bin && \
 
 * `lonesnake`
   * creates an environment with the latest CPython version, in the `.lonesnake` directory within the current working directory
-* `lonesnake --py 3.10`
-  * creates an environment with the latest patch of CPython 3.10
-* `lonesnake --py 3.10.0`
-  * creates an environment with CPython 3.10.0
+* `lonesnake --py 3.11`
+  * creates an environment with the latest patch of CPython 3.11
+* `lonesnake --py 3.11.0`
+  * creates an environment with CPython 3.11.0
 
 If a `.lonesnake` directory already exists, `lonesnake` will detect it and ask for confirmation interactively before deleting it.
 
@@ -139,7 +139,7 @@ export VIRTUAL_ENV="${lonesnake_dir}/venv"
 
 # Solve errors involving "Python.h not found" when building
 # Python extensions with a lonesnake environment.
-parent_include_dir="${lonesnake_dir}/interpreter/include"
+parent_include_dir="${lonesnake_dir}/interpreter/usr/local/include"
 if [[ -d "$parent_include_dir" ]]; then
   include_dir_name=$(find "$parent_include_dir" \
     -mindepth 1 -maxdepth 1 -type d -name "python3.*" \
@@ -169,7 +169,7 @@ export VIRTUAL_ENV="\${lonesnake_dir}/venv"
 
 # Solve errors involving "Python.h not found" when building
 # Python extensions with a lonesnake environment.
-parent_include_dir="\${lonesnake_dir}/interpreter/include"
+parent_include_dir="\${lonesnake_dir}/interpreter/usr/local/include"
 if [[ -d "\$parent_include_dir" ]]; then
   include_dir_name=\$(find "\$parent_include_dir" \
     -mindepth 1 -maxdepth 1 -type d -name "python3.*" \
@@ -183,7 +183,7 @@ EOM
 
 
 <details>
-<summary>If you wish to show a prefix in your shell prompt indicating whether a lonesnake venv is active (e.g. <code>🐍venv-3.10.4</code>), some code needs to be added to your <code>~/.bashrc</code> or <code>~/.zshrc</code> to check for activation. Click here to show an example code, but be aware it might need adjustments depending on the complexity of your prompt config.</summary>
+<summary>If you wish to show a prefix in your shell prompt indicating whether a lonesnake venv is active (e.g. <code>🐍venv-3.11.0</code>), some code needs to be added to your <code>~/.bashrc</code> or <code>~/.zshrc</code> to check for activation. Click here to show an example code, but be aware it might need adjustments depending on the complexity of your prompt config.</summary>
 
 ```bash
 show_lonesnake_venv_prefix () {
@@ -298,7 +298,7 @@ export PATH="${PIPX_BIN_DIR}:${PATH}"
 ## standalone environment structure
 
 This standalone environment directory includes a Python interpreter built from [source](https://www.python.org/downloads/source/), as well as a [venv](https://docs.python.org/3/library/venv.html). That is, the content of the `.lonesnake` directory is the following:
-* `interpreter` interpreter directory includes `bin`, `include`, etc...
-* `venv` venv directory includes `bin`, `include`, `pyvenv.cfg` etc... It is created by the interpreter above.
+* `interpreter` directory includes `usr/local/bin`, `usr/local/include`, etc...
+* `venv` directory includes `bin`, `include`, `pyvenv.cfg` etc... It is created by the interpreter above.
 
-Behind the scenes, `lonesnake` takes advantage of cache directories for the CPython source code and build files, located at `~/.cache/lonesnake/X.Y.Z/` where `X.Y.Z` is the Python version (e.g. `3.10.1`). These cache directories enable us to skip the compilation step when the CPython code was already compiled in the past for the requested version.
+Behind the scenes, `lonesnake` takes advantage of cache directories for the CPython source code and build files, located at `~/.cache/lonesnake/X.Y.Z/` where `X.Y.Z` is the Python version (e.g. `3.11.0`). These cache directories enable us to skip the compilation step when the CPython code was already compiled in the past for the requested version.

--- a/lonesnake
+++ b/lonesnake
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-readonly PROG_VERSION="0.15.0"
+readonly PROG_VERSION="0.16.0"
 
 PROG_NAME="$(basename "$0")"
 readonly PROG_NAME
@@ -23,10 +23,11 @@ readonly LATEST_PATCH_CP37="15"
 readonly LATEST_PATCH_CP38="15"
 readonly LATEST_PATCH_CP39="15"
 readonly LATEST_PATCH_CP310="8"
+readonly LATEST_PATCH_CP311="0"
 
 # Default CPython version if the user does not request a specific version
-readonly DEFAULT_CP_MINOR="3.10"
-readonly DEFAULT_CP_VERSION="${DEFAULT_CP_MINOR}.${LATEST_PATCH_CP310}"
+readonly DEFAULT_CP_MINOR="3.11"
+readonly DEFAULT_CP_VERSION="${DEFAULT_CP_MINOR}.${LATEST_PATCH_CP311}"
 
 # Color markers
 readonly CLR_BOLD="\033[1m"  # bold
@@ -161,6 +162,10 @@ function guess_cpython_patch_number() {
            echo "$LATEST_PATCH_CP310"
            return
         ;;
+        11)
+           echo "$LATEST_PATCH_CP311"
+           return
+        ;;
     esac
 
     error_out "Could not find the Python minor version '$minor' that you requested."
@@ -191,7 +196,7 @@ function create_standalone_dir() {
         "$interpreter_dir"
 
     local python_binary_name="python${cpython_major}.${cpython_minor}"
-    local standalone_rel_bin="${interpreter_rel_dir}/bin/${python_binary_name}"
+    local standalone_rel_bin="${interpreter_rel_dir}/usr/local/bin/${python_binary_name}"
     verify_interpreter "$standalone_version" "$standalone_rel_bin"
     echo
 
@@ -357,11 +362,9 @@ function compile_interpreter() {
     echo "➖ Running './configure' in Python interpreter source code directory" \
         "'$cache_source_dir'..."
     local start_configure_date="$SECONDS"
-    # We pass '--prefix ""' so all paths are relative to 'DESTDIR' at the 'make install'
-    # step later. If we don't set it, it is in /usr/local by default.
     local configure_output
     if ! configure_output="$(pushd "$cache_source_dir" && \
-            ./configure --prefix="" "$with_openssl_str" 2>&1 &&
+            ./configure "$with_openssl_str" 2>&1 &&
             popd)"; then
         echo "[ERROR] Detailed logs for '.configure':"
         echo "$configure_output"


### PR DESCRIPTION
Features:
- Add support for Python 3.11.0 following its release and make it the default
- Remove `--prefix=""` when configuring CPython build to support _bootstrap_python

As a downside, the prefix removal results in the installer being installed at `.lonesnake/interpreter/usr/local/bin/python` instead of `.lonesnake/interpreter/bin/python`. Below is the error encountered with _bootstrap_python after `configure`-ing with `--prefix=""` like in the previous versions:

```
./_bootstrap_python ./Programs/_freeze_module.py codecs ./Lib/codecs.py Python/frozen_modules/codecs.h Fatal Python error: init_import_site: Failed to import the site module Python runtime state: initialized
Traceback (most recent call last):
  File "/home/pierre/.cache/lonesnake/3.11.0/Lib/site.py", line 79, in <module>
Fatal Python error: init_import_site: Failed to import the site module Python runtime state: initialized
Traceback (most recent call last):
  File "/home/pierre/.cache/lonesnake/3.11.0/Lib/site.py", line 79, in <module>
    PREFIXES = [sys.prefix, sys.exec_prefix]
    PREFIXES = [sys.prefix, sys.exec_prefix]
                ^^^^^^^^^^
                ^^^^^^^^^^
AttributeError: module 'sys' has no attribute 'prefix'
AttributeError: module 'sys' has no attribute 'prefix'
Makefile:1209: recipe for target 'Python/frozen_modules/abc.h' failed
make: *** [Python/frozen_modules/abc.h] Error 1
```